### PR TITLE
Workaround for guest VM IP not within allowed VirtualBox hostonly network range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ubuntu Virtual Machine # 
+# Ubuntu Virtual Machine #
 
-This is a very flexible virtual machine that allows you to create a simple Ubuntu Server 20.04 LTS (Focal Fossa) for LAMP stack developers which also includes many related modern development tools. 
+This is a very flexible virtual machine that allows you to create a simple Ubuntu Server 20.04 LTS (Focal Fossa) for LAMP stack developers which also includes many related modern development tools.
 
 Please read all the document before start using the project.
 
@@ -36,14 +36,14 @@ $ vagrant up
 
 Once ready, you can test it by opening following URL on your browser:
 ```
-http://192.168.80.80/
-https://192.168.80.80/ (secure)
+http://192.168.62.101/
+https://192.168.62.101/ (secure)
 ```
 
 If you want to manage the MySQL database:
 ```
-http://192.168.80.80/phpmyadmin/
-https://192.168.80.80/phpmyadmin/ (secure)
+http://192.168.62.101/phpmyadmin/
+https://192.168.62.101/phpmyadmin/ (secure)
 
 Database Name : development
 User : root

--- a/vagrantfile
+++ b/vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
   config.vm.box = "estebanspina/lamp"
-  config.vm.network "private_network", ip: "192.168.80.80"
+  config.vm.network "private_network", ip: "192.168.62.101"
   config.vm.provider "virtualbox" do |vbox|
     vbox.cpus = "1"
     vbox.customize ["modifyvm", :id, "--uartmode1", "disconnected"]


### PR DESCRIPTION
When attempting to run vagrant up after upgrading to VirtualBox 6.1.28, the following error message is received:

There was an error while executing `VBoxManage`, a CLI used by Vagrant
for controlling VirtualBox. The command and stderr is shown below.

Command: ["hostonlyif", "ipconfig", "vboxnet0", "--ip", "192.168.80.1", "--netmask", "255.255.255.0"]

Stderr: VBoxManage: error: Code E_ACCESSDENIED (0x80070005) - Access denied (extended info not available)
VBoxManage: error: Context: "EnableStaticIPConfig(Bstr(pszIp).raw(), Bstr(pszNetmask).raw())" at line 242 of file VBoxManageHostonly.cpp

While this Vagrant issue is being solved
https://github.com/hashicorp/vagrant/pull/12564
...a workaround is to use an IP from the range 192.168.56.1 to 192.168.63.254.